### PR TITLE
use file-upload strategy of zoho to upload larger content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/go-resty/resty/v2 v2.10.0
+	github.com/gocarina/gocsv v0.0.0-20230616125104-99d496ca653d
 	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-resty/resty/v2 v2.10.0 h1:Qla4W/+TMmv0fOeeRqzEpXPLfTUnR5HZ1+lGs+CkiCo=
 github.com/go-resty/resty/v2 v2.10.0/go.mod h1:iiP/OpA0CkcL3IGt1O0+/SIItFUbkkyw5BGXiVdTu+A=
+github.com/gocarina/gocsv v0.0.0-20230616125104-99d496ca653d h1:KbPOUXFUDJxwZ04vbmDOc3yuruGvVO+LOa7cVER3yWw=
+github.com/gocarina/gocsv v0.0.0-20230616125104-99d496ca653d/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=

--- a/zoho.go
+++ b/zoho.go
@@ -100,14 +100,8 @@ func (s *ZohoService) ImportCSV(tableUri, csvData string, config map[string]stri
 func (s *ZohoService) sendAPIRequest(config map[string]string, additionalHeaders map[string]string, path, action string, body any, result any) error {
 	const errMsg = "could not send api request"
 
-	if additionalHeaders == nil {
-		additionalHeaders = map[string]string{}
-	}
-	additionalHeaders["User-Agent"] = "ZohoAnalytics GoLibrary"
-
 	request := s.restyClient.
 		R().
-		SetHeaders(additionalHeaders).
 		SetQueryParams(map[string]string{
 			"ZOHO_ACTION":        action,
 			"ZOHO_OUTPUT_FORMAT": outputFormat,
@@ -120,6 +114,10 @@ func (s *ZohoService) sendAPIRequest(config map[string]string, additionalHeaders
 
 	if body != nil {
 		request.SetBody(body)
+	}
+
+	if additionalHeaders != nil {
+		request.SetHeaders(additionalHeaders)
 	}
 
 	resp, err := request.Post(path)


### PR DESCRIPTION
Change file-upload strategy.
The current implemented strategy is using a header-param to transfer the data. The better way is to upload the CSV-Data as multipart/form-data.
Zoho Docu: https://www.zoho.com/analytics/api/#import-data

Change is made without breaking change for use of this lib.